### PR TITLE
fix: Refresh log listing when the workspace log dir changes

### DIFF
--- a/src/providers/activity-bar/env-config-provider.ts
+++ b/src/providers/activity-bar/env-config-provider.ts
@@ -5,6 +5,7 @@ import {
   WebviewView,
   WebviewViewProvider,
   env,
+  commands,
 } from "vscode";
 import { getNonce } from "../../core/nonce";
 import { WorkspaceStateManager } from "../workspace/workspace-state-provider";
@@ -16,6 +17,7 @@ import {
   InspectManager,
 } from "../inspect/inspect-manager";
 import { inspectVersionDescriptor } from "../../inspect/props";
+import { debounce } from "lodash";
 
 export const kActiveTaskChanged = "activeTaskChanged";
 export const kInitialize = "initialize";
@@ -143,6 +145,17 @@ export class EnvConfigurationProvider implements WebviewViewProvider {
                   env: this.env,
                 },
               });
+            }
+
+            if (data.default === "logDir") {
+              // The log dir was changed, update the task tree if needed
+              await debounce(
+                async () => {
+                  await commands.executeCommand("inspect.logListingUpdate");
+                },
+                500,
+                { leading: false, trailing: true }
+              )();
             }
 
             break;

--- a/src/providers/activity-bar/log-listing/log-listing-provider.ts
+++ b/src/providers/activity-bar/log-listing/log-listing-provider.ts
@@ -114,6 +114,13 @@ export async function activateLogListing(
     })
   );
 
+  // Register update command (for when the log directory changes )
+  disposables.push(
+    vscode.commands.registerCommand("inspect.logListingUpdate", () => {
+      updateTree();
+    })
+  );
+
   // Register Reveal in Explorer command
   disposables.push(
     vscode.commands.registerCommand(


### PR DESCRIPTION
We were watching the environment file for specific changes (made directly to the file), but if the Logging Configuration activity panel was used to edit the log directory, no environmentChanged event fires (since the change is being made by the environment context itself).

This will trigger a refresh remotely for this case.